### PR TITLE
TIME_WAIT state of server socket slowing down development

### DIFF
--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"httparsed": "1.2.1"
-	}
-}

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,0 +1,6 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"httparsed": "1.2.1"
+	}
+}

--- a/source/handy_httpd/server.d
+++ b/source/handy_httpd/server.d
@@ -49,7 +49,12 @@ class HttpServer {
 
     /**
      * Will be called before the socket is bound to the address. One can set
-     * special socket options in here by overriding it.
+     * special socket options in here by overriding it. 
+     * 
+     * Note: one application would be to add SocketOption.REUSEADDR, in 
+     * order to prevent long TIME_WAIT states preventing quick restarts 
+     * of the server after termination on some systems. Learn more about it
+     * here: https://stackoverflow.com/a/14388707.
      */
     protected void configurePreBind(Socket socket) {}
 

--- a/source/handy_httpd/server.d
+++ b/source/handy_httpd/server.d
@@ -47,6 +47,12 @@ class HttpServer {
         this.workerPool.isDaemon = true;
     }
 
+    /**
+     * Will be called before the socket is bound to the address. One can set
+     * special socket options in here by overriding it.
+     */
+    protected void configurePreBind(Socket socket) {}
+
     /** 
      * Starts the server on the calling thread, so that it will begin accepting
      * HTTP requests. Once the server is able to accept requests, `isReady()`
@@ -55,6 +61,7 @@ class HttpServer {
      */
     public void start() {
         serverSocket = new TcpSocket();
+        configurePreBind(serverSocket);
         serverSocket.bind(this.address);
         if (this.verbose) writefln!"Bound to address %s"(this.address);
         serverSocket.listen(this.connectionQueueSize);


### PR DESCRIPTION
Hello there, 

on my Linux system I've been encountering pretty long TIME_WAIT states before I can restart my server again (~2min). This slows down development. I'm very unexperienced in web sockets but I found that this issue could be fixed by setting the REUSEADDR option in the server socket (found in [this SO answer](https://stackoverflow.com/a/14388707)).

I'd like to propose this small change to the code base that allows users to set options before binding to an address, so that you can add REUSEADDR, for example, only if it's necessary on your system.

Usage example (in the context of the static file test):
```D
import std.socket;
import handy_httpd;
import handy_httpd.handlers.file_resolving_handler;


class NoWaitHttpServer : HttpServer {
    this(HttpRequestHandler handler) {
        super(handler);
    }

    override void configurePreBind(Socket socket) {
        socket.setOption(SocketOptionLevel.SOCKET, 
                SocketOption.REUSEADDR, 1);
    }
}


void main() {
	new NoWaitHttpServer(new FileResolvingHandler("content")).start();
}
```