### PR TITLE
Fixurlencoding

### DIFF
--- a/source/handy_httpd/components/form_urlencoded.d
+++ b/source/handy_httpd/components/form_urlencoded.d
@@ -82,7 +82,7 @@ QueryParam[] parseFormUrlEncoded(string queryString, bool stripWhitespace = true
  */
 private QueryParam parseSingleQueryParam(string s, bool stripWhitespace) {
     import std.string : strip, indexOf, replace;
-    import std.uri : decode;
+    import std.uri : decodeComponent;
 
     string name, value;
     ptrdiff_t idx = s.indexOf('=');
@@ -101,8 +101,8 @@ private QueryParam parseSingleQueryParam(string s, bool stripWhitespace) {
     }
 
     // Replace 0x2B ('+') with 0x20 (' ').
-    name = name.replace("+", " ").decode();
-    value = value.replace("+", " ").decode();
+    name = name.replace("+", " ").decodeComponent();
+    value = value.replace("+", " ").decodeComponent();
     if (stripWhitespace) {
         name = name.strip();
         value = value.strip();

--- a/source/handy_httpd/components/form_urlencoded.d
+++ b/source/handy_httpd/components/form_urlencoded.d
@@ -129,4 +129,7 @@ unittest {
         [QueryParam("a", ""), QueryParam("a", "hello"), QueryParam("a", "test"), QueryParam("b", "")],
         "a&a=hello&a=test&b"
     );
+
+    // test for replacement of reserved characters
+    doTest([QueryParam("time", "12:34:56")], "time=12%3A34%3A56");
 }


### PR DESCRIPTION
[std.uri.decode](https://dlang.org/phobos/std_uri.html#.decode) says: 
> Escape sequences that resolve to reserved URI characters are not replaced. 

I don't know what the purpose of that is, but I'm assuming it's some kind of partial decoding.

However, the next function, decodeComponent says:
> All escape sequences are decoded.

Which is what we want at this point.

Added a test for it.