### PR TITLE
Fix defaults in serverconfig so it's easier to use with named parameters or a constructor.

### DIFF
--- a/source/handy_httpd/components/config.d
+++ b/source/handy_httpd/components/config.d
@@ -14,38 +14,38 @@ struct ServerConfig {
     /** 
      * The hostname that the server will bind to.
      */
-    string hostname;
+    string hostname = "127.0.0.1";
 
     /** 
      * The port that the server will bind to.
      */
-    ushort port;
+    ushort port = 8080;
 
     /** 
      * The size of the buffer for receiving requests.
      */
-    size_t receiveBufferSize;
+    size_t receiveBufferSize = 8192;
 
     /** 
      * The number of connections to accept into the queue.
      */
-    int connectionQueueSize;
+    int connectionQueueSize = 100;
 
     /**
      * The size of the internal queue used for distributing requests to workers.
      */
-    size_t requestQueueSize;
+    size_t requestQueueSize = 128;
 
     /** 
      * The number of worker threads for processing requests.
      */
-    size_t workerPoolSize;
+    size_t workerPoolSize = 25;
 
     /**
      * The number of milliseconds that the worker pool manager should wait
      * between each health check it performs.
      */
-    uint workerPoolManagerIntervalMs;
+    uint workerPoolManagerIntervalMs = 60_000;
 
     /** 
      * An alias for a delegate function that can be used to modify a socket.
@@ -71,7 +71,7 @@ struct ServerConfig {
     /** 
      * Whether to set the REUSEADDR flag for the socket.
      */
-    bool reuseAddress;
+    bool reuseAddress = true;
 
     /** 
      * A set of default headers that are added to all HTTP responses.
@@ -83,19 +83,9 @@ struct ServerConfig {
      * is spawned to manage websocket connections, separate from the main
      * worker pool.
      */
-    bool enableWebSockets;
+    bool enableWebSockets = false;
 
     static ServerConfig defaultValues() {
-        ServerConfig cfg;
-        cfg.hostname = "127.0.0.1";
-        cfg.port = 8080;
-        cfg.receiveBufferSize = 8192;
-        cfg.requestQueueSize = 128;
-        cfg.connectionQueueSize = 100;
-        cfg.reuseAddress = true;
-        cfg.workerPoolSize = 25;
-        cfg.workerPoolManagerIntervalMs = 60_000;
-        cfg.enableWebSockets = false;
-        return cfg;
+        return ServerConfig.init;
     }
 }

--- a/source/handy_httpd/components/config.d
+++ b/source/handy_httpd/components/config.d
@@ -85,6 +85,7 @@ struct ServerConfig {
      */
     bool enableWebSockets = false;
 
+    deprecated("Use ServerConfig.init")
     static ServerConfig defaultValues() {
         return ServerConfig.init;
     }

--- a/source/handy_httpd/server.d
+++ b/source/handy_httpd/server.d
@@ -101,7 +101,7 @@ class HttpServer {
      */
     this(
         HttpRequestHandler handler = noOpHandler(),
-        ServerConfig config = ServerConfig.defaultValues
+        ServerConfig config = ServerConfig.init
     ) {
         this.config = config;
         this.address = parseAddress(config.hostname, config.port);
@@ -122,7 +122,7 @@ class HttpServer {
      */
     this(
         HttpRequestHandlerFunction handlerFunc,
-        ServerConfig config = ServerConfig.defaultValues
+        ServerConfig config = ServerConfig.init
     ) {
         this(toHandler(handlerFunc), config);
     }


### PR DESCRIPTION
With latest compilers, you can use named parameters, giving a much nicer experience with config structs like this:

```d
auto server = new HttpServer(&handler, ServerConfig(hostname: "0.0.0.0", port: 8181, enableWebSockets: true));
```
In order for this to work, you need sensible defaults on the struct fields themselves.